### PR TITLE
Overhaul resources folder code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,11 +49,11 @@ pub struct GeneralSettings {
 
 impl GeneralSettings {
     pub fn is_auth_key_valid(&self) -> bool {
-        return if let Some(auth_key) = &self.auth_key {
+        if let Some(auth_key) = &self.auth_key {
             Uuid::parse_str(auth_key.as_str()).is_ok()
         } else {
             false
-        };
+        }
     }
 
     /// Returns the client resource path, and ensures it exists.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
+use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use uuid::Uuid;
+use crate::fs_util;
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -51,6 +53,22 @@ impl GeneralSettings {
             Uuid::parse_str(auth_key.as_str()).is_ok()
         } else {
             false
-        }
+        };
+    }
+
+    /// Returns the client resource path, and ensures it exists.
+    /// Default is Resources/Client.
+    pub fn get_client_resource_folder(&self) -> anyhow::Result<String> {
+        let res_client_path = Path::new(self.resource_folder.as_str()).join("Client");
+        fs_util::ensure_path_exists(&res_client_path)?;
+        Ok(fs_util::path_to_string(res_client_path))
+    }
+
+    /// Returns the server resource path, and ensures it exists.
+    /// Default is Resources/Server.
+    pub fn get_server_resource_folder(&self) -> anyhow::Result<String> {
+        let res_server_path = Path::new(self.resource_folder.as_str()).join("Server");
+        fs_util::ensure_path_exists(&res_server_path)?;
+        Ok(fs_util::path_to_string(res_server_path))
     }
 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+/// Ensures the given path exists by creating it if it doesn't.
+pub fn ensure_path_exists(path: &PathBuf) -> anyhow::Result<()> {
+    if !path.exists() {
+        debug!("Path {:?} doesn't exist, creating it", path);
+        std::fs::create_dir_all(path)?;
+    }
+    Ok(())
+}
+
+/// Joins a parent folder and a sub-path, resolving the subpath beforehand to ensure that
+/// the resulting path is still within the parent folder, regardless of ".." in the sub-path.
+pub fn join_path_secure(parent: &Path, sub: &Path) -> anyhow::Result<PathBuf> {
+    Ok(parent.join(sub.canonicalize()?.as_path()))
+}
+
+/// Converts a PathBuf into a String in a lossy way. This is generally the way we want to do it
+/// in the server.
+pub fn path_to_string(path: PathBuf) -> String {
+    path.into_os_string().to_string_lossy().to_string()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #[macro_use] extern crate async_trait;
 #[macro_use] extern crate lazy_static;
 
+use std::path::Path;
 use argh::FromArgs;
 
 use std::sync::Arc;
@@ -12,6 +13,7 @@ mod tui;
 mod server;
 mod config;
 mod heartbeat;
+mod fs_util;
 
 #[derive(FromArgs)]
 /// BeamMP Server v3.3.0
@@ -40,8 +42,12 @@ async fn main() {
         .map_err(|_| error!("Failed to parse config file!"))
         .expect("Failed to parse config file!");
 
-    // TODO: This should not error lol
-    for entry in std::fs::read_dir("Resources/Client").expect("Failed to read Resources/Client!") {
+
+    let client_resources = user_config.general
+        .get_client_resource_folder()
+        .expect("Failed to create the client resource folder");
+
+    for entry in std::fs::read_dir(client_resources).expect("Failed to read client resource folder!") {
         if let Ok(entry) = entry {
             if entry.path().is_file() {
                 if let Ok(metadata) = entry.metadata() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -161,7 +161,7 @@ impl Server {
 
         let server_resource_folder = config.general
             .get_server_resource_folder()
-            .expect("Failed to create the client resource folder");
+            .expect("Failed to create the server resource folder");
 
         // Load existing plugins
         let plugins = load_plugins(server_resource_folder);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -27,11 +27,12 @@ pub use plugins::*;
 pub use http::*;
 
 pub use crate::config::Config;
+use crate::config::GeneralSettings;
 
-fn load_plugins() -> Vec<Plugin> {
+fn load_plugins(server_resource_folder: String) -> Vec<Plugin> {
     let mut plugins = Vec::new();
 
-    for res_entry in std::fs::read_dir("Resources/Server").expect("Failed to read Resources/Server!") {
+    for res_entry in std::fs::read_dir(server_resource_folder).expect("Failed to read server resource folder!") {
         if let Ok(res_entry) = res_entry {
             let res_path = res_entry.path();
             if res_path.is_dir() {
@@ -158,8 +159,12 @@ impl Server {
             Arc::new(UdpSocket::bind(bind_addr).await?)
         };
 
+        let server_resource_folder = config.general
+            .get_server_resource_folder()
+            .expect("Failed to create the client resource folder");
+
         // Load existing plugins
-        let plugins = load_plugins();
+        let plugins = load_plugins(server_resource_folder);
 
         // Start client runtime
         let (clients_incoming_tx, clients_incoming_rx) = mpsc::channel(100);


### PR DESCRIPTION
I've made a few adjustments.

The core idea is that 

1) The resource folder isn't always "Resources", and instead can be *any path*.
2) Resource folders Client and Server need to be created if they don't exist (same with the Resources folder itself, whatever/whereever it is).
3) Client mods can currently request "/something/../../../../passwords.txt", as far as I can tell. Either way, the fix is to canonicalize the mod path, then join it with the resource folder. That's `fs_util::join_path_secure`.